### PR TITLE
Create provider interfaces

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,30 @@
+name: Go CI
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: "go.mod"
+          cache: true
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Build project
+        run: go build -v ./...
+
+      - name: Run tests
+        run: go test -v ./...

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -7,17 +7,39 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
         with:
-          go-version: "go.mod"
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Download Go modules
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v ./...
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
           cache: true
 
       - name: Download Go modules
@@ -25,6 +47,3 @@ jobs:
 
       - name: Build project
         run: go build -v ./...
-
-      - name: Run tests
-        run: go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,17 @@ all: proto test
 
 # --- Proto Management ---
 
-## lint: Run buf lint to check for AIP/Buf style violations
+## lint: Lint proto files and Go files
 lint:
 	@echo "Running buf lint..."
 	@$(BUF_BIN) lint
+	@echo "Linting go files..."
+	@golint ./...
 
-## format: Automatically format proto files to standard style
+## format: Format proto files and Go files
 format:
+	@echo "Formatting go files..."
+	@gofmt -s -w .
 	@echo "Formatting proto files..."
 	@$(BUF_BIN) format -w
 
@@ -65,7 +69,12 @@ db/init-test:
 db/shell:
 	@docker exec -it $(DB_CONTAINER) psql -U $(DB_USER) -d $(DB_NAME)
 
-# --- Testing ---
+# --- CI ---
+
+## build: Build the application
+build:
+	@echo "Building the application..."
+	go build ./...
 
 ## test: Run unit tests
 test:

--- a/internal/domain/bingo_service.go
+++ b/internal/domain/bingo_service.go
@@ -18,6 +18,6 @@ func (s *BingoService) GetBingoCard(ctx context.Context, cardID string) (*BingoC
 }
 
 // UpdateBingoCard updates the layout or goal assignments within a bingo card.
-func (s *BingoService) UpdateBingoCard(ctx context.Context, cardID string, card *BingoCard, update map[string]any) (*BingoCard, error) {
+func (s *BingoService) UpdateBingoCard(ctx context.Context, cardID string, update map[string]any) (*BingoCard, error) {
 	return &BingoCard{}, nil
 }

--- a/internal/domain/bingo_service.go
+++ b/internal/domain/bingo_service.go
@@ -13,7 +13,7 @@ func (s *BingoService) CreateBingoCard(ctx context.Context, newCard *BingoCard) 
 }
 
 // GetBingoCard retrieves the bingo card for a specific year and month.
-func (s *BingoService) GetBingoCard(ctx context.Context, year int32, month int32) (*BingoCard, error) {
+func (s *BingoService) GetBingoCard(ctx context.Context, cardID string) (*BingoCard, error) {
 	return &BingoCard{}, nil
 }
 

--- a/internal/domain/goal_service.go
+++ b/internal/domain/goal_service.go
@@ -19,12 +19,12 @@ func (s *GoalService) GetGoal(ctx context.Context, goalID string) (*Goal, error)
 }
 
 // ListGoals returns a paginated list of Goals belonging to the parent resource.
-func (s *GoalService) ListGoals(ctx context.Context, parentID string) ([]*Goal, error) {
-	return []*Goal{}, nil
+func (s *GoalService) ListGoals(ctx context.Context, parent string, pageSize int32, pageToken string) ([]*Goal, string, error) {
+	return []*Goal{}, "", nil
 }
 
 // UpdateGoal updates specific fields of an existing Goal using a FieldMask.
-func (s *GoalService) UpdateGoal(ctx context.Context, goalID string, goal *Goal, update map[string]any) (*Goal, error) {
+func (s *GoalService) UpdateGoal(ctx context.Context, goalID string, update map[string]any) (*Goal, error) {
 	return &Goal{}, nil
 }
 

--- a/internal/server/provider.go
+++ b/internal/server/provider.go
@@ -14,7 +14,7 @@ type GoalProvider interface {
 	// GetGoal retrieves a domain goal by its internal ID.
 	GetGoal(ctx context.Context, id string) (*domain.Goal, error)
 	// It returns the list of goals and the token for the next page.
-    ListGoals(ctx context.Context, parentID string, pageSize int32, pageToken string) ([]*domain.Goal, string, error)
+	ListGoals(ctx context.Context, parentID string, pageSize int32, pageToken string) ([]*domain.Goal, string, error)
 	// UpdateGoal applies updates to a domain model.
 	UpdateGoal(ctx context.Context, id string, updates map[string]any) (*domain.Goal, error)
 	// DeleteGoal archives a goal.
@@ -28,4 +28,6 @@ type BingoProvider interface {
 	CreateBingoCard(ctx context.Context, card *domain.BingoCard) (*domain.BingoCard, error)
 	// GetBingoCard retrieves a bingo card by its internal ID.
 	GetBingoCard(ctx context.Context, id string) (*domain.BingoCard, error)
+	// UpdateBingoCard applies updates to a bingo card.
+	UpdateBingoCard(ctx context.Context, id string, updates map[string]any) (*domain.BingoCard, error)
 }

--- a/internal/server/provider.go
+++ b/internal/server/provider.go
@@ -1,0 +1,31 @@
+package server
+
+import (
+	"context"
+
+	"github.com/bibyen/totle-tasks/internal/domain" // Your domain models
+)
+
+// GoalProvider manages business logic using pure domain models.
+// The Server implementation is responsible for converting Proto -> Domain.
+type GoalProvider interface {
+	// CreateGoal handles the logic of saving a new goal.
+	CreateGoal(ctx context.Context, goal *domain.Goal) (*domain.Goal, error)
+	// GetGoal retrieves a domain goal by its internal ID.
+	GetGoal(ctx context.Context, id string) (*domain.Goal, error)
+	// ListGoals returns a slice of domain goals and pagination info.
+	ListGoals(ctx context.Context, parentID string, limit int, offset int) ([]*domain.Goal, error)
+	// UpdateGoal applies updates to a domain model.
+	UpdateGoal(ctx context.Context, id string, updates map[string]any) (*domain.Goal, error)
+	// DeleteGoal archives a goal.
+	DeleteGoal(ctx context.Context, id string) error
+}
+
+// BingoProvider manages the bingo grid logic using domain models.
+// The Server implementation is responsible for converting Proto -> Domain.
+type BingoProvider interface {
+	// CreateBingoCard creates a new bingo card for a specific period.
+	CreateBingoCard(ctx context.Context, card *domain.BingoCard) (*domain.BingoCard, error)
+	// GetBingoCard retrieves a bingo card by its internal ID.
+	GetBingoCard(ctx context.Context, id string) (*domain.BingoCard, error)
+}

--- a/internal/server/provider.go
+++ b/internal/server/provider.go
@@ -13,8 +13,8 @@ type GoalProvider interface {
 	CreateGoal(ctx context.Context, goal *domain.Goal) (*domain.Goal, error)
 	// GetGoal retrieves a domain goal by its internal ID.
 	GetGoal(ctx context.Context, id string) (*domain.Goal, error)
-	// ListGoals returns a slice of domain goals and pagination info.
-	ListGoals(ctx context.Context, parentID string, limit int, offset int) ([]*domain.Goal, error)
+	// It returns the list of goals and the token for the next page.
+    ListGoals(ctx context.Context, parentID string, pageSize int32, pageToken string) ([]*domain.Goal, string, error)
 	// UpdateGoal applies updates to a domain model.
 	UpdateGoal(ctx context.Context, id string, updates map[string]any) (*domain.Goal, error)
 	// DeleteGoal archives a goal.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,9 +11,8 @@ import (
 type Server struct {
 	totletasksv1connect.UnimplementedGoalServiceHandler
 	totletasksv1connect.UnimplementedBingoServiceHandler
-
-	GoalService  *domain.GoalService
-	BingoService *domain.BingoService
+	goalService  GoalProvider
+	bingoService BingoProvider
 }
 
 // NewServer returns a new Server instance.
@@ -26,7 +25,7 @@ func NewServer(goalService *domain.GoalService, bingoService *domain.BingoServic
 	}
 
 	return &Server{
-		GoalService:  goalService,
-		BingoService: bingoService,
+		goalService:  goalService,
+		bingoService: bingoService,
 	}, nil
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,15 +4,15 @@ package server
 import (
 	"testing"
 
-	"github.com/bibyen/totle-tasks/internal/service"
+	"github.com/bibyen/totle-tasks/internal/domain"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestNewServer_Success(t *testing.T) {
 	t.Run("server created successfully", func(t *testing.T) {
-		goalService := &service.GoalService{}
-		bingoService := &service.BingoService{}
+		goalService := &domain.GoalService{}
+		bingoService := &domain.BingoService{}
 
 		_, gotErr := NewServer(goalService, bingoService)
 		require.NoError(t, gotErr)
@@ -22,19 +22,19 @@ func TestNewServer_Success(t *testing.T) {
 func TestNewServer_Failure(t *testing.T) {
 	tests := []struct {
 		name         string
-		goalService  *service.GoalService
-		bingoService *service.BingoService
+		goalService  *domain.GoalService
+		bingoService *domain.BingoService
 		errMsg       string
 	}{
 		{
 			name:         "Nil GoalService",
 			goalService:  nil,
-			bingoService: &service.BingoService{},
+			bingoService: &domain.BingoService{},
 			errMsg:       "goalService cannot be nil",
 		},
 		{
 			name:         "Nil BingoService",
-			goalService:  &service.GoalService{},
+			goalService:  &domain.GoalService{},
 			bingoService: nil,
 			errMsg:       "bingoService cannot be nil",
 		},


### PR DESCRIPTION
Closes #8 

- Defines GoalProvider interface with same method signatures as GoalService
  - ListGoals follows pagination approach from proto
- Defines BingoProvider interface with same method signatures as BingoService
- NewServer accepts interfaces as arguments
- Server struct stores interfaces instead of concrete pointers
- Adds workflow for build + test Go code